### PR TITLE
Fix mapper typos directly in html output

### DIFF
--- a/0.2.2/modules/generated/mapper/visualization/gtda.mapper.visualization.plot_interactive_mapper_graph.html
+++ b/0.2.2/modules/generated/mapper/visualization/gtda.mapper.visualization.plot_interactive_mapper_graph.html
@@ -645,7 +645,7 @@ color Mapper nodes according to any column in <cite>data</cite> (still using
 <li><p><strong>clone_pipeline</strong> (bool, optional, default: <code class="docutils literal notranslate"><span class="pre">True</span></code>) – If <code class="docutils literal notranslate"><span class="pre">True</span></code>, the input <cite>pipeline</cite> is cloned before computing the
 Mapper graph to prevent unexpected side effects from in-place
 parameter updates.</p></li>
-<li><p><strong>n_sig_figs</strong> (int or None, optional, default: <code class="docutils literal notranslate"><span class="pre">3</span></code>) – If not <code class="docutils literal notranslate"><span class="pre">None</span></code>, number of significant figures to which to round node
+<li><p><strong>n_sig_figs</strong> (int or None, optional, default: <code class="docutils literal notranslate"><span class="pre">3</span></code>) – If not <code class="docutils literal notranslate"><span class="pre">None</span></code>, number of significant figures to which to round
 node summary statistics. If <code class="docutils literal notranslate"><span class="pre">None</span></code>, no rounding is performed.</p></li>
 <li><p><strong>node_scale</strong> (int or float, optional, default: <code class="docutils literal notranslate"><span class="pre">12</span></code>) – Sets the scale factor used to determine the rendered size of the
 nodes. Increase for larger nodes. Implements a formula in the

--- a/0.2.2/modules/generated/mapper/visualization/gtda.mapper.visualization.plot_static_mapper_graph.html
+++ b/0.2.2/modules/generated/mapper/visualization/gtda.mapper.visualization.plot_static_mapper_graph.html
@@ -645,7 +645,7 @@ color Mapper nodes according to any column in <cite>data</cite> (still using
 <li><p><strong>clone_pipeline</strong> (bool, optional, default: <code class="docutils literal notranslate"><span class="pre">True</span></code>) – If <code class="docutils literal notranslate"><span class="pre">True</span></code>, the input <cite>pipeline</cite> is cloned before computing the
 Mapper graph to prevent unexpected side effects from in-place
 parameter updates.</p></li>
-<li><p><strong>n_sig_figs</strong> (int or None, optional, default: <code class="docutils literal notranslate"><span class="pre">3</span></code>) – If not <code class="docutils literal notranslate"><span class="pre">None</span></code>, number of significant figures to which to round node
+<li><p><strong>n_sig_figs</strong> (int or None, optional, default: <code class="docutils literal notranslate"><span class="pre">3</span></code>) – If not <code class="docutils literal notranslate"><span class="pre">None</span></code>, number of significant figures to which to round
 node summary statistics. If <code class="docutils literal notranslate"><span class="pre">None</span></code>, no rounding is performed.</p></li>
 <li><p><strong>node_scale</strong> (int or float, optional, default: <code class="docutils literal notranslate"><span class="pre">12</span></code>) – Sets the scale factor used to determine the rendered size of the
 nodes. Increase for larger nodes. Implements a formula in the

--- a/latest/modules/generated/mapper/visualization/gtda.mapper.visualization.plot_interactive_mapper_graph.html
+++ b/latest/modules/generated/mapper/visualization/gtda.mapper.visualization.plot_interactive_mapper_graph.html
@@ -645,7 +645,7 @@ color Mapper nodes according to any column in <cite>data</cite> (still using
 <li><p><strong>clone_pipeline</strong> (bool, optional, default: <code class="docutils literal notranslate"><span class="pre">True</span></code>) – If <code class="docutils literal notranslate"><span class="pre">True</span></code>, the input <cite>pipeline</cite> is cloned before computing the
 Mapper graph to prevent unexpected side effects from in-place
 parameter updates.</p></li>
-<li><p><strong>n_sig_figs</strong> (int or None, optional, default: <code class="docutils literal notranslate"><span class="pre">3</span></code>) – If not <code class="docutils literal notranslate"><span class="pre">None</span></code>, number of significant figures to which to round node
+<li><p><strong>n_sig_figs</strong> (int or None, optional, default: <code class="docutils literal notranslate"><span class="pre">3</span></code>) – If not <code class="docutils literal notranslate"><span class="pre">None</span></code>, number of significant figures to which to round
 node summary statistics. If <code class="docutils literal notranslate"><span class="pre">None</span></code>, no rounding is performed.</p></li>
 <li><p><strong>node_scale</strong> (int or float, optional, default: <code class="docutils literal notranslate"><span class="pre">12</span></code>) – Sets the scale factor used to determine the rendered size of the
 nodes. Increase for larger nodes. Implements a formula in the

--- a/latest/modules/generated/mapper/visualization/gtda.mapper.visualization.plot_static_mapper_graph.html
+++ b/latest/modules/generated/mapper/visualization/gtda.mapper.visualization.plot_static_mapper_graph.html
@@ -645,7 +645,7 @@ color Mapper nodes according to any column in <cite>data</cite> (still using
 <li><p><strong>clone_pipeline</strong> (bool, optional, default: <code class="docutils literal notranslate"><span class="pre">True</span></code>) – If <code class="docutils literal notranslate"><span class="pre">True</span></code>, the input <cite>pipeline</cite> is cloned before computing the
 Mapper graph to prevent unexpected side effects from in-place
 parameter updates.</p></li>
-<li><p><strong>n_sig_figs</strong> (int or None, optional, default: <code class="docutils literal notranslate"><span class="pre">3</span></code>) – If not <code class="docutils literal notranslate"><span class="pre">None</span></code>, number of significant figures to which to round node
+<li><p><strong>n_sig_figs</strong> (int or None, optional, default: <code class="docutils literal notranslate"><span class="pre">3</span></code>) – If not <code class="docutils literal notranslate"><span class="pre">None</span></code>, number of significant figures to which to round
 node summary statistics. If <code class="docutils literal notranslate"><span class="pre">None</span></code>, no rounding is performed.</p></li>
 <li><p><strong>node_scale</strong> (int or float, optional, default: <code class="docutils literal notranslate"><span class="pre">12</span></code>) – Sets the scale factor used to determine the rendered size of the
 nodes. Increase for larger nodes. Implements a formula in the


### PR DESCRIPTION
Experimenting with the idea of bypassing the whole deployment cycle from giotto-tda, when only small typos are involved. What do you think @wreise ?